### PR TITLE
NPE when convert object to bytes

### DIFF
--- a/src/main/java/cascading/hbase/HBaseScheme.java
+++ b/src/main/java/cascading/hbase/HBaseScheme.java
@@ -187,7 +187,7 @@ public class HBaseScheme extends HBaseAbstractScheme {
 				   objectInBytes = Bytes.toBytes(coercible.coerce( object, String.class ).toString());
 				}
 				else {
-					objectInBytes = Bytes.toBytes(object.toString());
+					objectInBytes = object == null ? null : Bytes.toBytes(object.toString());
 				}
 
 				if (null == objectInBytes) {


### PR DESCRIPTION
The field value could be null, will get NPE when convert it String then to bytes.
