### PR TITLE
HBase Security

### DIFF
--- a/src/main/java/cascading/hbase/HBaseTap.java
+++ b/src/main/java/cascading/hbase/HBaseTap.java
@@ -26,10 +26,14 @@ import org.apache.hadoop.hbase.mapreduce.TableOutputFormat;
 
 import cascading.hbase.helper.TableInputFormat;
 
+import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputCollector;
 import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,6 +154,26 @@ public class HBaseTap extends Tap<JobConf, RecordReader, OutputCollector> {
 		return hBaseAdmin;
 	}
 
+    private void obtainToken(JobConf conf) {
+        if (User.isHBaseSecurityEnabled(conf)) {
+            String user = conf.getUser();
+            LOG.info("obtaining HBase token for: {}", user);
+            try {
+                UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
+                user = currentUser.getUserName();
+                Credentials credentials = conf.getCredentials();
+                for(Token t : currentUser.getTokens()) {
+                    LOG.debug("Token {} is available", t);
+                    //there must be HBASE_AUTH_TOKEN exists, if not bad thing will happen, it's must be generated when job submission.
+                    if ("HBASE_AUTH_TOKEN".equalsIgnoreCase(t.getKind().toString())) {
+                        credentials.addToken(t.getKind(), t);
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to obtain HBase auth token for " + user, e);
+            }
+        }
+    }
 
 
 	public boolean resourceExists(JobConf conf) throws IOException {
@@ -166,8 +190,9 @@ public class HBaseTap extends Tap<JobConf, RecordReader, OutputCollector> {
 		LOG.debug("sinking to table: {}", tableName);
 		// TODO: next 5 lines were added, and commented area was taken out
 		// hbase table wasn't being created during tests... wtf?
+        obtainToken(conf);
 		try {
-			createResource(conf);
+            createResource(conf);
 		} catch (IOException e) {
 			throw new RuntimeException(tableName + " does not exist !");
 		}
@@ -196,7 +221,7 @@ public class HBaseTap extends Tap<JobConf, RecordReader, OutputCollector> {
 		LOG.debug("sourcing from table: {}", tableName);
 		FileInputFormat.addInputPaths(conf, tableName);
         conf.set(TableInputFormat.INPUT_TABLE, tableName);
-    
+        obtainToken(conf);
 		super.sourceConfInit(flowProcess, conf);
 	}
 


### PR DESCRIPTION
Within a secured Hadoop cluster (Kerberos authentication enabled), just like delegation tokens are required to access HDFS data and run MapReduce jobs, a token is also need to interact with HBase.

Current implementation of HBaseTap doesn't handle token, read and write data from/to will get exceptions:

```
Caused by: GSSException: No valid credentials provided (Mechanism level: Failed to find any Kerberos tgt)     
at sun.security.jgss.krb5.Krb5InitCredential.getInstance(Krb5InitCredential.java:130) 
at sun.security.jgss.krb5.Krb5MechFactory.getCredentialElement(Krb5MechFactory.java:106)
at sun.security.jgss.krb5.Krb5MechFactory.getMechanismContext(Krb5MechFactory.java:172)
at sun.security.jgss.GSSManagerImpl.getMechanismContext(GSSManagerImpl.java:209)
at sun.security.jgss.GSSContextImpl.initSecContext(GSSContextImpl.java:195) 
at sun.security.jgss.GSSContextImpl.initSecContext(GSSContextImpl.java:162)
at com.sun.security.sasl.gsskerb.GssKrb5Client.evaluateChallenge(GssKrb5Client.java:175)
 ... 55 more
2013-11-06 22:28:12,807 WARN cascading.tap.hadoop.io.MultiInputFormat: unable to get record reader, but not retryingjava.io.IOException: Cannot create a record reader because of a previous error. Please look at the previous logs lines from the task's full log for more details.
at cascading.hbase.helper.TableInputFormatBase.getRecordReader(TableInputFormatBase.java:93)
at cascading.tap.hadoop.io.MultiInputFormat$1.operate(MultiInputFormat.java:252)
at cascading.tap.hadoop.io.MultiInputFormat$1.operate(MultiInputFormat.java:247
at cascading.util.Util.retry(Util.java:730)
at cascading.tap.hadoop.io.MultiInputFormat.getRecordReader(MultiInputFormat.java:246)
at org.apache.hadoop.mapred.MapTask$TrackedRecordReader.<init>(MapTask.java:190)
at org.apache.hadoop.mapred.MapTask.runOldMapper(MapTask.java:411)
```

```
org.apache.hadoop.hbase.security.AccessDeniedException: 
at cascading.hbase.HBaseTap.sinkConfInit(HBaseTap.java:53)        
at cascading.hbase.HBaseTapCollector.initialize(HBaseTapCollector.java:83)        
at cascading.hbase.HBaseTapCollector.prepare(HBaseTapCollector.java:74)        
at cascading.hbase.HBaseTap.openForWrite(HBaseTap.java:147)        
at cascading.hbase.HBaseTap.openForWrite(HBaseTap.java:53)        
at cascading.flow.stream.SinkStage.prepare(SinkStage.java:60)        
at cascading.flow.stream.StreamGraph.prepare(StreamGraph.java:167)        
at cascading.flow.hadoop.FlowMapper.run(FlowMapper.java:110)        
at org.apache.hadoop.mapred.MapTask.runOldMapper(MapTask.java:429)        
at org.apache.hadoop.mapred.MapTask.run(MapTask.java:365)        
at org.apache.hadoop.mapred.Child$4.run(Child.java:255)        
at java.security.AccessController.doPrivileged(Native Method)        
at javax.security.auth.Subject.doAs(Subject.java:396)        
at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1232)        
at org.apache.hadoop.mapred.Child.main(Child.java:249)
```
